### PR TITLE
update pdu.c

### DIFF
--- a/includes/pdu.c
+++ b/includes/pdu.c
@@ -72,7 +72,8 @@ EncodePDUMessage(const char* sms_text, int sms_text_length, unsigned char* outpu
 		}
 	}
 
-	if (i <= sms_text_length)
+
+	if (i < sms_text_length)
 		output_buffer[output_buffer_length++] =	(sms_text[i] & BITMASK_7BITS) >> (carry_on_bits - 1);
 
 	return output_buffer_length;


### PR DESCRIPTION
In static int EncodePDUMessage

"if (i <= sms_text_length)"    is replace by "if (i < sms_text_length)"

I find this error when I used with module GSM UL865-EUR because i was an error when i convert in PDU with sms_text_length == 16 and not error if sms_text_length is 15 or 17
